### PR TITLE
Fix markdown syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ class Question extends React.Component {
 }
 ````
 
-if you are not using es6 compiler like [babel](https://babeljs.io/) or (rollup)[http://rollupjs.org/] it's possible to include icons from the compiled folder ```./lib```. Babel by [default](http://babeljs.io/docs/usage/require/#usage) will ignore ```node_modules``` so if you don't want to change that settings you will need to use files from the ```./lib```
+if you are not using es6 compiler like [babel](https://babeljs.io/) or [rollup.js](http://rollupjs.org/) it's possible to include icons from the compiled folder ```./lib```. Babel by [default](http://babeljs.io/docs/usage/require/#usage) will ignore ```node_modules``` so if you don't want to change that settings you will need to use files from the ```./lib```
 
 ```javascript
 var FaBeer = require('react-icons/lib/fa/beer');


### PR DESCRIPTION
Hi, I found markdown syntax error about `rollup.js` link so I fixed it

Thank you