### PR TITLE
Update react-icon-base to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "react-icon-base": "2.0.4"
+    "react-icon-base": "2.0.5"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
Upgrading to react 15.5 causes the proptypes warning to throw. Using CRA, this fails tests. `react-icon-base` has been updated to reflect this, but a `yarn add react-icons` is still installing `2.0.4`