### PR TITLE
Create-react-app update in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ With ```react-icons```, you can send icons that are specified instead of one big
 `create-react-app` tries to load the icons as files by default, rather than running through Babel. You may therefore see an erorr message similar to "You may need an appropriate loader...". The recommended workaround is to import from `lib` instead:
 
 ```javascript
-import FaBeer from 'react-icons/lib/fa/beer';
+import { FaBeer } from 'react-icons/lib/fa';
 ```
 
 ## Related


### PR DESCRIPTION
More than one icon can be imported at once and without having to reference the very specific file, just by curling the imports. 
Moreover, it makes IDEs like `vscode` able to give import suggestions.

So instead of:
```
import FaBeer from 'react-icons/lib/fa/beer'
import FaCloudUpload from 'react-icons/lib/fa/cloud-upload'
```

You do:
```
import { FaBeer, FaCloudUpload } from 'react-icons/lib/fa'
```