### PR TITLE
Upgrade react-icon-base to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "react-icon-base": "2.0.7"
+    "react-icon-base": "2.1.0"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
Upgrade it to latest version.
Changelog: https://github.com/gorangajic/react-icon-base/compare/f513a09649b3cccf7ff08f60e2a40e9e0ef0e758...863b88117916aea71f330659da6ba7f9720c8154

No feature change but fixes the packaging around `prop-types` dependency.
This fix the installation of `react-icons` for project already requiring a locked version of `prop-types`.