### PR TITLE
Update package.json peer dependency to React v16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0|| ^15.0.0 || ^16.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "react-icon-base": "2.0.7"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "validate-commit-msg": "^2.6.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^16.0.0"
   },
   "dependencies": {
     "react-icon-base": "2.0.7"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "validate-commit-msg": "^2.6.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0|| ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "react-icon-base": "2.0.7"


### PR DESCRIPTION
We are not able to use npm shrinkwrap because of this "react": "^0.14.0 || ^15.0.0" dependency in our project. It seems like react-icons wokrs good with React 16.0